### PR TITLE
Fixed: use correct variable for decorator when editorState is created…

### DIFF
--- a/src/components/Smoke.jsx
+++ b/src/components/Smoke.jsx
@@ -15,7 +15,7 @@ export default class Smoke extends React.Component {
             const contentState = JSON.parse(props.defaultValue);
             var editorState = editorStateFromRaw(contentState, this.decorator);
         } else {
-            var editorState = editorStateFromRaw(null, myDecorator);
+            var editorState = editorStateFromRaw(null, this.decorator);
         }
 
         this.state = {


### PR DESCRIPTION
… empty