### PR TITLE
Tnre 2348 fix datafactory embed https

### DIFF
--- a/src/Helpers/EmbedConfig.jsx
+++ b/src/Helpers/EmbedConfig.jsx
@@ -8,7 +8,7 @@ export default  {
     GOOGLEMAP: {domObj:"IFRAME",compare:{attr:"src",value:"google.com/maps"}, blockName:"googlemap"},
     SOUNDCLOUD: {domObj:"IFRAME",compare:{attr:"src",value:"w.soundcloud.com/player"}, blockName:"soundcloud"},
     SCRIBD: {domObj:"IFRAME",compare:{attr:"src",value:"scribd.com/embeds"}, blockName:"scribd"},
-    DATAFACTORY: {domObj:"IFRAME",compare:{attr:"src",value:"http://mam.tn.com.ar/html/v3/"}, blockName:"datafactory"},
+    DATAFACTORY: {domObj:"IFRAME",compare:{attr:"src",value:"https://mam.tn.com.ar/html/v3/"}, blockName:"datafactory"},
     WAZE: {domObj:"IFRAME",compare:{attr:"src",value:"https://embed.waze.com"}, blockName:"waze"},
     RADIOCUT: {domObj:"IFRAME",compare:{attr:"src",value:"radiocut.fm/audiocut/embed"}, blockName:"radiocut"},
     INFOGRAM: {domObj:"DIV",compare:{attr:"class",value:"infogram-embed"}, blockName:"infogram"},

--- a/src/Helpers/SocialEmbed.jsx
+++ b/src/Helpers/SocialEmbed.jsx
@@ -5,7 +5,7 @@ import embedsList from './EmbedConfig';
 export default class socialEmbed {
 
     static cleanHtml(string) {
-        const regex = /<(\w+)[^>]*>.*<\/(\w+)>/g;
+        const regex = /<(\w+)[^>]*>/g;
         const str =  S(string).stripTags('p','a','time').s;
 
         if (regex.test(str)) {


### PR DESCRIPTION
- Se modifico "http" por "https" en Datafactory para que funciona el AMP.
- Se modifico la expresión regular  "/<(\w+)[^>]*>/g;" en  SocialEmbed.js