### PR TITLE
chore: upgrade dev dependency require-dir to version 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"react-hot-loader": "next",
 		"react-modal-dialog": "^4.0.7",
 		"react-resumable-js": "^1.1.23",
-		"require-dir": "^0.3.1",
+		"require-dir": "^0.3.2",
 		"sass-loader": "^6.0.5",
 		"string": "^3.3.3",
 		"style-loader": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,9 +4554,10 @@ request@2, request@^2.79.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-require-dir@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.3.1.tgz#b5a8e28bae0343bb0d0cc38ab1f531e1931b264a"
+require-dir@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.3.2.tgz#c1d5c75e9fbffde9f2e6b33e383db4f594b5a6a9"
+  integrity sha1-wdXHXp+//eny5rM+OD209ZS1pqk=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Current version (0.3.1) breaks when dev app is started.
https://github.com/aseemk/requireDir/issues/59